### PR TITLE
Fix OpenProjectComponent on recent version of IntelliJ

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
     <id>com.bashorov.mainMenuToggler</id>
     <name>Main Menu toggler</name>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
     <vendor email="bashorov@gmail.com">bashor</vendor>
 
     <description><![CDATA[
@@ -9,6 +9,10 @@
         ]]></description>
     \
     <change-notes><![CDATA[
+      <p>0.2.1:</p>
+      <ul>
+        <li>Fixed restoring of persisted state on recent versions of the IntelliJ platform.</li>
+      </ul>
       <p>0.2.0:</p>
       <ul>
         <li>Added persisted state after loading a project. </li>

--- a/src/com/bashorov/mainMenuToggler/OpenProjectComponent.kt
+++ b/src/com/bashorov/mainMenuToggler/OpenProjectComponent.kt
@@ -1,6 +1,7 @@
 package com.bashorov.mainMenuToggler
 
 import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.ApplicationComponent
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
@@ -25,7 +26,9 @@ class OpenProjectComponent : ApplicationComponent, ProjectManagerListener {
     override fun projectOpened(project: Project?) {
         val state: Boolean = PropertiesComponent.getInstance().getBoolean("is_menu_visible")
 
-        project?.getMenuBar()?.isVisible = state
+        ApplicationManager.getApplication().invokeLater {
+            project?.getMenuBar()?.isVisible = state
+        }
     }
 
     override fun projectClosed(project: Project?) {


### PR DESCRIPTION
In 2017.2 WindowManagerEx#getFrame(Project) returns null when
projectOpened() gets called, so we need to schedule triggering of
visibility for later.